### PR TITLE
add registry command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+
+definitions:
+  orb-dev-ref: &orb-dev-ref cobli/npm-config@dev:${CIRCLE_BRANCH}
+  orb-prod-ref: &orb-prod-ref cobli/npm-config@${CIRCLE_TAG}
+  publish-parameters: &publish-parameters
+    context: circleci-api-token
+    orb-path: src/orb.yml
+    validate: true
+  
+orbs:
+  orb-tools: circleci/orb-tools@8.27.4
+
+workflows:
+  btd:
+    jobs:
+      - orb-tools/publish:
+          <<: *publish-parameters      
+          orb-ref: *orb-dev-ref
+      - orb-tools/publish:
+          <<: *publish-parameters
+          orb-ref: *orb-prod-ref
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# npm config for CircleCI
+# npm config commands for CircleCI
 
-[CircleCI Orb](https://circleci.com/docs/2.0/orb-intro/) commands to change NPM configurations
+[CircleCI Orb](https://circleci.com/docs/2.0/orb-intro/) commands to change NPM configuration
 
-See [examples](src/orb.yaml)
+See [examples](https://circleci.com/orbs/registry/orb/cobli/npm-config#usage-examples)

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,0 +1,58 @@
+---
+version: 2.1
+description: Changes npm configuration
+
+examples:
+  setting_registry:
+    description: Sets a registry in NPM client (~/.npmrc) 
+    usage:
+      version: 2.1
+      orbs:
+        npm-config: cobli/npm-config@x.x.x
+      jobs:
+        test:
+          docker:
+            - image: circleci/node:9.11.2
+          steps:
+            - checkout
+            - npm-config/set-registry:
+                registry-prurl: //your.registry.domain.net/path/
+                scope: "@your-scope"
+                auth-token: "your-repo-token"
+            - run:
+                name: Download depencies
+                command: yarn
+            - run:
+                name: Test
+                command: yarn test
+
+commands:
+  set-registry:
+    description: Sets a registry to .npmrc
+    parameters:
+      registry-prurl:
+        description: |
+          protocol-relative URL (ex: //registry.domain.net/path/)
+        type: string
+      scope:
+        description: registry scope
+        type: string
+      auth-token:
+        description: authorization token for private repos
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Set NPM registry URL
+          command: >
+            scope=<< parameters.scope >>;
+            registry_prurl=<< parameters.registry-prurl >>;
+            npm config set "${scope}:registry" "https:$registry_prurl"
+      - run:
+          name: Set auth token for NPM registry if provided
+          command: |
+            if [ "<< parameters.auth-token >>" != "" ]; then
+            registry_prurl=<< parameters.registry-prurl >>;
+            auth_token=<< parameters.auth-token >>;
+            echo "${registry_prurl}:_authToken=${auth_token}" >> ~/.npmrc
+            fi;


### PR DESCRIPTION
This orb was first published `inline` inside herbie-dashboard in [`.circleci/config.yml`](https://github.com/Cobliteam/herbie-dashboard/blob/master/.circleci/config.yml#L153).

Now we need it for herbie-api, so we are exposing it to the orb repository (it's a public project)

In addition, we are using [orb-tools](https://circleci.com/orbs/registry/orb/circleci/orb-tools) from CircleCI to `continuous deliver` dev and production versions (production deployment triggers when any [Semver](https://semver.org/) tag, as `1.3.2`, is pushed to the repo)